### PR TITLE
#46 ツアー詳細にツアー情報を紐づけるよう変更

### DIFF
--- a/api/app/controllers/api/v1/tourdetail_controller.rb
+++ b/api/app/controllers/api/v1/tourdetail_controller.rb
@@ -1,36 +1,17 @@
 class Api::V1::TourdetailController < ApplicationController
   # ツアー詳細を表示
   def index
-    # guide_schedules = GuideSchedule.includes(:guide)#.where(tour_id: params[:id])#.includes(:Guides)
-    testa = GuideSchedule.where(tour_id: params[:id]).includes(:guide).to_json
+    # 必要な情報を取得
     tours = Tour.find_by(id: params[:id])
-    tour_guides = TourGuide.where(tour_id: params[:id])
+    tour_guides = TourGuide.where(tour_id: params[:id]).includes(:guide)
+    guide_schedules = GuideSchedule.where(tour_id: params[:id]).includes(:guide)
 
-    # guide_schedules_and_guide = []
-
-    logger.debug(testa)
-    # for guide_schedule in guide_schedules
-    # GuideSchedule.includes(:guide)
-    # end
-
-    # for guide_schedule in guide_schedules
-    # logger.debug(guide_schedules)
-    #   hash = Hash.new
-    #   guide = Guide.where(id:guide_schedule.guide_id)
-    #   #guide_schedules_and_guide.push(guide_schedule.merge!(guide_schedules => guide))
-    #   hash2 = guide_schedule
-
-    #   hash1 = {"経営学" => 75, "会社法" => 65}
-
-    #   hash3 = hash2.merge!(hash1)
-
-    #   #hash["guide"] = guide
-    #   guide_schedules_and_guide.push(hash3)
-    #   guide_schedule = guide_schedule.guide_id
-
-    # end
-
-    response = { tour: tours, guide_schedules: guide_schedules, tour_guides: tour_guides }
+    # レスポンスの形を作成
+    response = {
+      tour: tours,
+      guide_schedules: JSON.parse(guide_schedules.to_json(include: [:guide])),
+      tour_guides: JSON.parse(tour_guides.to_json(include: [:guide]))
+    }
     render json: json_render_v1(true, response)
   end
 end

--- a/api/app/controllers/api/v1/tourdetail_controller.rb
+++ b/api/app/controllers/api/v1/tourdetail_controller.rb
@@ -1,11 +1,36 @@
 class Api::V1::TourdetailController < ApplicationController
   # ツアー詳細を表示
   def index
-    guideschedules = GuideSchedule.where(tour_id: params[:id])
+    # guide_schedules = GuideSchedule.includes(:guide)#.where(tour_id: params[:id])#.includes(:Guides)
+    testa = GuideSchedule.where(tour_id: params[:id]).includes(:guide).to_json
     tours = Tour.find_by(id: params[:id])
-    tourguides = TourGuide.where(tour_id: params[:id])
+    tour_guides = TourGuide.where(tour_id: params[:id])
 
-    response = { tour: tours, guideschedule: guideschedules, tourguide: tourguides }
+    # guide_schedules_and_guide = []
+
+    logger.debug(testa)
+    # for guide_schedule in guide_schedules
+    # GuideSchedule.includes(:guide)
+    # end
+
+    # for guide_schedule in guide_schedules
+    # logger.debug(guide_schedules)
+    #   hash = Hash.new
+    #   guide = Guide.where(id:guide_schedule.guide_id)
+    #   #guide_schedules_and_guide.push(guide_schedule.merge!(guide_schedules => guide))
+    #   hash2 = guide_schedule
+
+    #   hash1 = {"経営学" => 75, "会社法" => 65}
+
+    #   hash3 = hash2.merge!(hash1)
+
+    #   #hash["guide"] = guide
+    #   guide_schedules_and_guide.push(hash3)
+    #   guide_schedule = guide_schedule.guide_id
+
+    # end
+
+    response = { tour: tours, guide_schedules: guide_schedules, tour_guides: tour_guides }
     render json: json_render_v1(true, response)
   end
 end

--- a/api/app/models/guide_schedule.rb
+++ b/api/app/models/guide_schedule.rb
@@ -1,2 +1,3 @@
 class GuideSchedule < ApplicationRecord
+  belongs_to :guide
 end

--- a/api/app/models/tour_guide.rb
+++ b/api/app/models/tour_guide.rb
@@ -1,2 +1,3 @@
 class TourGuide < ApplicationRecord
+  belongs_to :guide
 end


### PR DESCRIPTION
`render` で返す際にネストした hash は設定しないとネスト部分が無視されるようなので、一度文字列にした後、もう一度Hash化しています（無駄な部分なので後で修正したい）。

## ガイドの紐づけができなかった原因
- Modelで関連付けの設定が必要でした。

## 参考サイト
- [Active Record の関連付け - Railsガイド](https://railsguides.jp/association_basics.html)

## 確認内容
- ツアー詳細取得時に、ガイド情報が紐づけられ、レスポンスにガイド情報が含まれること