### PR TITLE
#67 ツアー担当ガイドの設定用APIを作成

### DIFF
--- a/api/app/controllers/api/v1/tour_guides_controller.rb
+++ b/api/app/controllers/api/v1/tour_guides_controller.rb
@@ -17,6 +17,9 @@ class Api::V1::TourGuidesController < ApplicationController
         t = TourGuide.new(tour_id: tour_id, guide_id: g)
         t.save
       end
+
+      # ツアーの状態を担当者決定済みに更新
+      Tour.find(tour_id).update(tour_state_code: TOUR_STATE_CODE_ASSIGNED)
     end
 
     # TODO: 成功時はメールを送信 #75 で実装予定

--- a/api/app/controllers/api/v1/tour_guides_controller.rb
+++ b/api/app/controllers/api/v1/tour_guides_controller.rb
@@ -1,0 +1,37 @@
+# ツアー担当ガイド詳細のコントローラーです
+class Api::V1::TourGuidesController < ApplicationController
+  before_action :require_login
+
+  # 担当ガイドを設定するためのAPI
+  def create
+    # トランザクション（失敗時は保存しない）
+    ApplicationRecord.transaction do
+      tour_id = params[:id]
+      guides = params[:guides]
+
+      # 同じツアーIDの担当情報を削除（物理）
+      TourGuide.where(tour_id: tour_id).destroy_all
+
+      # 追加（TODO: 削除済みのガイドを指定した場合はエラー）
+      for g in guides
+        t = TourGuide.new(tour_id: tour_id, guide_id: g)
+        t.save
+      end
+    end
+
+    # TODO: 成功時はメールを送信 #75 で実装予定
+
+    # 成功時
+    render json: json_render_v1(true)
+    return
+
+    # バリデーションエラー
+    ActiveRecord RecodeInvalid: e
+    render json: json_render_v1(false, { hint => "validation error" })
+    nil
+
+    # その他失敗時
+  rescue StandardError => e
+    render json: json_render_v1(false)
+  end
+end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -15,6 +15,9 @@ Rails.application.routes.draw do
           get "tours" => "tours#index"
           get "tours/:id" => "tour#index"
           delete "tours/:id" => "tour#destroy"
+
+          # 担当ガイド
+          post "tours/:id/guides" => "tour_guides#create"
         end
     end
 


### PR DESCRIPTION
ツアー担当ガイドを指定するためのAPIを作成しました。確認をお願いいたします。

## 機能の説明
- https://github.com/e-harp-intern/R4FY/wiki/tour-id-guides-post

## 確認事項
- 存在するガイドを担当者として割り当て、担当を割り当てることができること
- ツアー状態コードを、担当者決定済みに変更できること

## 参考にしたサイト
- [【Rails】 updateメソッドの使い方を徹底解説！ | Pikawaka](https://pikawaka.com/rails/update)