### PR TITLE
#89 ツアー終了時刻のバリデーションを追加

### DIFF
--- a/api/app/models/tour.rb
+++ b/api/app/models/tour.rb
@@ -3,4 +3,5 @@ class Tour < ApplicationRecord
   has_many :guide_schedules
   has_many :tour_guides
   has_many :tokens
+  validates :end_datetime, comparison: { greater_than: :start_datetime }
 end


### PR DESCRIPTION
ツアー時刻のバリデーションを設定しました

## 確認事項
- ツアー作成時に終了時刻より前の開始時刻を設定すると、正しく登録できること
- ツアー作成時に終了時刻より後の開始時刻を設定すると、エラーとなること