### PR TITLE
#105 ツアー一覧取得APIに検索条件を追加

### DIFF
--- a/api/app/controllers/api/v1/tours_controller.rb
+++ b/api/app/controllers/api/v1/tours_controller.rb
@@ -6,7 +6,11 @@ class Api::V1::ToursController < ApplicationController
 
   # ツアー一覧を降順取得
   def index
-    tours = Tour.order(start_datetime: :DESC)
+    # 条件の初期値を設定
+    limit = params[:limit] || 100
+
+    # 検索
+    tours = Tour.order(start_datetime: :DESC).limit(limit)
     render json: json_render_v1(true, tours)
   end
 

--- a/api/app/controllers/api/v1/tours_controller.rb
+++ b/api/app/controllers/api/v1/tours_controller.rb
@@ -8,9 +8,17 @@ class Api::V1::ToursController < ApplicationController
   def index
     # 条件の初期値を設定
     limit = params[:limit] || 100
+    word = params[:word] || ""
+    start_date = Date.parse(params[:start_date] || Date.today.prev_month.strftime("%Y-%m-%d"))
+    end_date = Date.parse(params[:end_date] || Date.today.strftime("%Y-%m-%d")).tomorrow
 
     # 検索
-    tours = Tour.order(start_datetime: :DESC).limit(limit)
+    tours = Tour
+            .where("name LIKE ?", "%#{word}%")
+            .where("end_datetime < ?", end_date)
+            .where("start_datetime > ?", start_date)
+            .order(start_datetime: :DESC)
+            .limit(limit)
     render json: json_render_v1(true, tours)
   end
 

--- a/api/app/controllers/api/v1/tours_controller.rb
+++ b/api/app/controllers/api/v1/tours_controller.rb
@@ -10,8 +10,8 @@ class Api::V1::ToursController < ApplicationController
     limit = params[:limit] || 100
     word = params[:word] || ""
     start_date = Date.parse(params[:start_date] || Date.today.prev_month.strftime("%Y-%m-%d"))
-    end_date = Date.parse(params[:end_date] || Date.today.strftime("%Y-%m-%d")).tomorrow
-    tour_state = params[:tour_state] || [TOUR_STATE_CODE_INCOMPLETE, TOUR_STATE_CODE_ASSIGNED, TOUR_STATE_CODE_COMPLETE, TOUR_STATE_CODE_COMPLETE_RECORDED, TOUR_STATE_CODE_CANCEL]
+    end_date = Date.parse(params[:end_date] || "9999-12-30").tomorrow
+    tour_state = params[:tour_state] || [TOUR_STATE_CODE_INCOMPLETE, TOUR_STATE_CODE_ASSIGNED, TOUR_STATE_CODE_COMPLETE]
 
     # 検索
     tours = Tour
@@ -19,7 +19,7 @@ class Api::V1::ToursController < ApplicationController
             .where("name LIKE ?", "%#{word}%")
             .where("end_datetime < ?", end_date)
             .where("start_datetime > ?", start_date)
-            .order(start_datetime: :DESC)
+            .order(start_datetime: :ASC)
             .limit(limit)
     render json: json_render_v1(true, tours)
   end

--- a/api/app/controllers/api/v1/tours_controller.rb
+++ b/api/app/controllers/api/v1/tours_controller.rb
@@ -11,9 +11,11 @@ class Api::V1::ToursController < ApplicationController
     word = params[:word] || ""
     start_date = Date.parse(params[:start_date] || Date.today.prev_month.strftime("%Y-%m-%d"))
     end_date = Date.parse(params[:end_date] || Date.today.strftime("%Y-%m-%d")).tomorrow
+    tour_state = params[:tour_state] || [TOUR_STATE_CODE_INCOMPLETE, TOUR_STATE_CODE_ASSIGNED, TOUR_STATE_CODE_COMPLETE, TOUR_STATE_CODE_COMPLETE_RECORDED, TOUR_STATE_CODE_CANCEL]
 
     # 検索
     tours = Tour
+            .where(tour_state_code: tour_state)
             .where("name LIKE ?", "%#{word}%")
             .where("end_datetime < ?", end_date)
             .where("start_datetime > ?", start_date)


### PR DESCRIPTION
ツアー一覧取得時に検索条件を指定できるようにしました。デフォルトの条件は #105 と [tours · e-harp-intern/R4FY Wiki](https://github.com/e-harp-intern/R4FY/wiki/tours) に記載しています。

## 動作の確認
- 指定した単語を含むツアーを検索できること
- 検索条件が正しく動くこと
- 開始日・終了日を設定できること
- ツアー状態で検索できること
- デフォルト値が意図したとおりに動作すること