### PR TITLE
#122 ガイドの実績を登録するAPIを作成

### DIFF
--- a/api/app/controllers/api/v1/achievements_controller.rb
+++ b/api/app/controllers/api/v1/achievements_controller.rb
@@ -1,0 +1,12 @@
+# 実績を入力するためのコントローラー
+class Api::V1::AchievementsController < ApplicationController
+  before_action :require_login
+
+  # 実績を入力
+  def create
+    # createですが、updateで保存しています
+    achievements = TourGuide.find_by(id: params[:tour_id], id: params[:guide_id])
+    achievements.update(achievements_entered: false)
+    render json: json_render_v1(true, achievements)
+  end
+end

--- a/api/app/controllers/api/v1/achievements_controller.rb
+++ b/api/app/controllers/api/v1/achievements_controller.rb
@@ -5,8 +5,20 @@ class Api::V1::AchievementsController < ApplicationController
   # 実績を入力
   def create
     # createですが、updateで保存しています
-    achievements = TourGuide.find_by(id: params[:tour_id], id: params[:guide_id])
-    achievements.update(achievements_entered: achievements)
+    tour_id = Tour.find_by(id: params[:tour_id]).id
+    guide_id = Guide.find_by(id: params[:guide_id]).id
+    achievements = TourGuide.find_by(tour_id: tour_id, guide_id: guide_id)
+    attend = params[:attend]
+    memo = params[:memo]
+    # 実績入力
+    achievements.update(achievements_entered: true)
+
+    # 出席だけ入力
+    achievements.update(attend: attend) unless attend.nil?
+    # メモだけ入力
+    achievements.update(memo: memo) unless memo.nil?
+
+    # 結果を出力
     render json: json_render_v1(true, achievements)
   end
 end

--- a/api/app/controllers/api/v1/achievements_controller.rb
+++ b/api/app/controllers/api/v1/achievements_controller.rb
@@ -5,16 +5,18 @@ class Api::V1::AchievementsController < ApplicationController
   # 実績を入力
   def create
     # createですが、updateで保存しています
-    tour_id = Tour.find_by(id: params[:tour_id]).id
-    guide_id = Guide.find_by(id: params[:guide_id]).id
+    tour_id = params[:tour_id]
+    guide_id = params[:guide_id]
     achievements = TourGuide.find_by(tour_id: tour_id, guide_id: guide_id)
     attend = params[:attend]
     memo = params[:memo]
+
     # 実績入力
     achievements.update(achievements_entered: true)
 
     # 出席だけ入力
     achievements.update(attend: attend) unless attend.nil?
+
     # メモだけ入力
     achievements.update(memo: memo) unless memo.nil?
 

--- a/api/app/controllers/api/v1/achievements_controller.rb
+++ b/api/app/controllers/api/v1/achievements_controller.rb
@@ -6,7 +6,7 @@ class Api::V1::AchievementsController < ApplicationController
   def create
     # createですが、updateで保存しています
     achievements = TourGuide.find_by(id: params[:tour_id], id: params[:guide_id])
-    achievements.update(achievements_entered: false)
+    achievements.update(achievements_entered: achievements)
     render json: json_render_v1(true, achievements)
   end
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
           delete "admins/:id" => "admins#delete"
           get "guides/:token/schedules" => "guide_schedules#index"
           patch "guides/:token/schedules" => "guide_schedules#update"
+          post "achievements/:tour_id/achievements/:guide_id" => "achievements#create"
 
           # ツアー
           post "tours" => "tours#create"

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
           delete "admins/:id" => "admins#delete"
           get "guides/:token/schedules" => "guide_schedules#index"
           patch "guides/:token/schedules" => "guide_schedules#update"
-          post "achievements/:tour_id/achievements/:guide_id" => "achievements#create"
+          post "tours/:tour_id/achievements/:guide_id" => "achievements#create"
 
           # ツアー
           post "tours" => "tours#create"


### PR DESCRIPTION
## 作業内容
- ガイドの実績を登録するAPIを作成。当初の指定URLは`localhost:3000/api/v1/tours/[tour_id]/achievements/[guide_id]`だったが、新しくファイルを作成したため`localhost:3000/api/v1/achievements/[tour_id]/achievements/[guide_id]`に変更している
## 確認内容
- postmanでの出力とDBのデータが変更されていることを確認