### PR TITLE
#198 トークンでページを開くことができるようにページコントローラーに機能を追加

### DIFF
--- a/api/app/controllers/api/v1/guide_schedules_controller.rb
+++ b/api/app/controllers/api/v1/guide_schedules_controller.rb
@@ -1,7 +1,7 @@
 # ガイドの予定に関連する機能のコントローラーです
 
 class Api::V1::GuideSchedulesController < ApplicationController
-  before_action :require_login
+  before_action :require_login, except: %i[index update]
 
   # DBにガイドスケジュール(true/false)を反映
   def update

--- a/api/app/controllers/front_controller.rb
+++ b/api/app/controllers/front_controller.rb
@@ -7,9 +7,19 @@ class FrontController < ActionController::Base
     if @current_user
       render file: Rails.root.join("public/index.html"), status: 200, layout: false,
              content_type: "text/html"
+      return
     end
 
-    # TODO: トークンでのログインチェック
+    # トークンでのログインチェック
+    path = request.fullpath.split("/")
+    if path.length >= 4 && path[1] == "guides" && path[3] == "schedules"
+      token = path[2]
+      if Token.find_by(token: token) != nil
+        render file: Rails.root.join("public/index.html"), status: 200, layout: false,
+               content_type: "text/html"
+        return
+      end
+    end
 
     # 権限がない場合はログインページへリダイレクト
     redirect_to "/"


### PR DESCRIPTION
検証環境で、ガイドの予定入力時にページを開くことができるように。