### PR TITLE
#206 ページ読み込み時にデフォルトレイアウトのメニューが一瞬見える問題を修正

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -45,10 +45,9 @@ export default {
   },
   methods: {
     layout() {
-      const layout = this.$route.meta.layout
-        ? `${this.$route.meta.layout}-layout`
-        : "default-layout";
-      return layout;
+      const layoutName = this.$route.meta.layout;
+      const layout = layoutName ? `${layoutName}-layout` : "default-layout";
+      return this.$route.name ? layout : "none-layout";
     },
     LoadComplete(flg) {
       this.loading = !flg;


### PR DESCRIPTION
ページ名がついていない場合は何もないレイアウトを表示させるように変更しました。
