### PR TITLE
#175 ツアー単位で予定入力を求めたガイドの実績情報をすべて取得するAPIの作成

### DIFF
--- a/api/app/controllers/api/v1/tour_achievements_controller.rb
+++ b/api/app/controllers/api/v1/tour_achievements_controller.rb
@@ -1,0 +1,19 @@
+# ツアー実績のコントローラーです
+class Api::V1::TourAchievementsController < ApplicationController
+  include Achievement
+  before_action :require_login
+
+  # ツアーに紐づくガイドの実績を取得する（スケジュール入力を求めたガイドの実績一覧）
+  def index
+    # 取得するガイドのリスト
+    guides = GuideSchedule.where(tour_id: params[:tour_id])
+
+    # 情報を取得
+    achievements = []
+    guides.each do |guide|
+      achievements.push(achievement(guide.guide_id))
+    end
+
+    render json: json_render_v1(true, achievements)
+  end
+end

--- a/api/app/controllers/api/v1/tour_achievements_controller.rb
+++ b/api/app/controllers/api/v1/tour_achievements_controller.rb
@@ -14,6 +14,8 @@ class Api::V1::TourAchievementsController < ApplicationController
       achievements.push(achievement(guide.guide_id))
     end
 
-    render json: json_render_v1(true, achievements)
+    response = {}
+    response["achievements"] = achievements
+    render json: json_render_v1(true, response)
   end
 end

--- a/api/app/controllers/concerns/achievement.rb
+++ b/api/app/controllers/concerns/achievement.rb
@@ -9,6 +9,9 @@ module Achievement
     achievement = {}
     today = Date.today
 
+    # ガイド情報を追加
+    achievement["guide_id"] = guide_id
+
     # 前回出席ツアーを検索
     achievement["lasttime"] = TourGuide
                               .where(guide_id: guide_id, achievements_entered: true) # 指定ガイドの入力済み実績のみ取得

--- a/api/app/controllers/concerns/achievement.rb
+++ b/api/app/controllers/concerns/achievement.rb
@@ -1,0 +1,51 @@
+# 実績関連の共通処理です
+module Achievement
+  include Common
+  extend ActiveSupport::Concern
+
+  # 指定したIDのガイドの実績を取得する
+  def achievement(guide_id, month = 3, tour_num = 5)
+    # 初期値
+    achievement = {}
+    today = Date.today
+
+    # 前回出席ツアーを検索
+    achievement["lasttime"] = TourGuide
+                              .where(guide_id: guide_id, achievements_entered: true) # 指定ガイドの入力済み実績のみ取得
+                              .joins(:tour) # ツアーを結合
+                              .select("tours.*") # ツアー情報のみを取得
+                              .where.not("tour_state_code = ?", TOUR_STATE_CODE_CANCEL) # 中止ツアーを除く
+                              .order(start_datetime: "DESC") # 開始日順に並び替え（可能なら最大値を使用）
+                              .first # 先頭の開始日のみ取得
+
+    # 最新 tour_num 回 の出席したツアーのリストを取得
+    achievement["participation_days"] = TourGuide
+                                        .where(guide_id: guide_id, achievements_entered: true)
+                                        .joins(:tour)
+                                        .select("tours.*")
+                                        .where.not("tour_state_code = ?", TOUR_STATE_CODE_CANCEL)
+                                        .order(start_datetime: "DESC")
+                                        .limit(tour_num)
+
+    # 過去（今日から指定月前） month 月 に出席したツアーの回数を取得
+    achievement["participation_num"] = TourGuide
+                                       .where(guide_id: guide_id, achievements_entered: true)
+                                       .joins(:tour)
+                                       .select("tours.*")
+                                       .where.not("tour_state_code = ?", TOUR_STATE_CODE_CANCEL)
+                                       .where("start_datetime <= ?", today)
+                                       .where("start_datetime > ?", today.ago(month.month))
+                                       .count(:id)
+
+    # 参加予定のツアーのリスト（今日以降）
+    achievement["assign"] = TourGuide
+                            .where(guide_id: guide_id)
+                            .joins(:tour)
+                            .select("tours.*")
+                            .where("start_datetime > ?", today)
+                            .where("tour_state_code = ?", TOUR_STATE_CODE_ASSIGNED) # 担当者割り当て済みのみから取得
+
+    # 返すデータ
+    achievement
+  end
+end

--- a/api/app/controllers/concerns/achievement.rb
+++ b/api/app/controllers/concerns/achievement.rb
@@ -13,22 +13,22 @@ module Achievement
     achievement["guide_id"] = guide_id
 
     # 前回出席ツアーを検索
-    achievement["lasttime"] = TourGuide
-                              .where(guide_id: guide_id, achievements_entered: true) # 指定ガイドの入力済み実績のみ取得
-                              .joins(:tour) # ツアーを結合
-                              .select("tours.*") # ツアー情報のみを取得
-                              .where.not("tour_state_code = ?", TOUR_STATE_CODE_CANCEL) # 中止ツアーを除く
-                              .order(start_datetime: "DESC") # 開始日順に並び替え（可能なら最大値を使用）
-                              .first # 先頭の開始日のみ取得
+    achievement["last_tour"] = TourGuide
+                               .where(guide_id: guide_id, achievements_entered: true) # 指定ガイドの入力済み実績のみ取得
+                               .joins(:tour) # ツアーを結合
+                               .select("tours.*") # ツアー情報のみを取得
+                               .where.not("tour_state_code = ?", TOUR_STATE_CODE_CANCEL) # 中止ツアーを除く
+                               .order(start_datetime: "DESC") # 開始日順に並び替え（可能なら最大値を使用）
+                               .first # 先頭の開始日のみ取得
 
     # 最新 tour_num 回 の出席したツアーのリストを取得
-    achievement["participation_days"] = TourGuide
-                                        .where(guide_id: guide_id, achievements_entered: true)
-                                        .joins(:tour)
-                                        .select("tours.*")
-                                        .where.not("tour_state_code = ?", TOUR_STATE_CODE_CANCEL)
-                                        .order(start_datetime: "DESC")
-                                        .limit(tour_num)
+    achievement["participation_tours"] = TourGuide
+                                         .where(guide_id: guide_id, achievements_entered: true)
+                                         .joins(:tour)
+                                         .select("tours.*")
+                                         .where.not("tour_state_code = ?", TOUR_STATE_CODE_CANCEL)
+                                         .order(start_datetime: "DESC")
+                                         .limit(tour_num)
 
     # 過去（今日から指定月前） month 月 に出席したツアーの回数を取得
     achievement["participation_num"] = TourGuide
@@ -41,12 +41,12 @@ module Achievement
                                        .count(:id)
 
     # 参加予定のツアーのリスト（今日以降）
-    achievement["assign"] = TourGuide
-                            .where(guide_id: guide_id)
-                            .joins(:tour)
-                            .select("tours.*")
-                            .where("start_datetime > ?", today)
-                            .where("tour_state_code = ?", TOUR_STATE_CODE_ASSIGNED) # 担当者割り当て済みのみから取得
+    achievement["assign_tours"] = TourGuide
+                                  .where(guide_id: guide_id)
+                                  .joins(:tour)
+                                  .select("tours.*")
+                                  .where("start_datetime > ?", today)
+                                  .where("tour_state_code = ?", TOUR_STATE_CODE_ASSIGNED) # 担当者割り当て済みのみから取得
 
     # 返すデータ
     achievement

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
           delete "tours/:id" => "tour#destroy"
 
           # ツアー／実績
+          get "tours/:tour_id/achievements" => "tour_achievements#index"
           post "tours/:tour_id/achievements/:guide_id" => "achievements#create"
 
           # ツアー／担当ガイド


### PR DESCRIPTION
## 確認したこと
- 各情報が正しく取得されること。