### PR TITLE
#253 初回起動手順にSERVER_PATHの設定を追加

### DIFF
--- a/docs/初回起動手順.md
+++ b/docs/初回起動手順.md
@@ -59,6 +59,9 @@ SMTP_OPENSSL_VERIFY = none #
 #SMTP_AUTH_PASS = #
 
 MAIL_FROM = Service Admin <noreply@example.com>
+
+# Server URL for mail message
+SERVER_PATH = "http://localhost:8080"
 ```
 
 ### 起動してみる


### PR DESCRIPTION
説明を追加しました。設定が追加されたので、未設定の方は設定を追記後、`docker-compose stop`, `docker-compose up`で再起動してください。