### PR TITLE
#241 管理者詳細を取得

### DIFF
--- a/api/app/controllers/api/v1/admins_controller.rb
+++ b/api/app/controllers/api/v1/admins_controller.rb
@@ -1,6 +1,5 @@
 # 管理者アカウントを作成するためのコントローラー
 class Api::V1::AdminsController < ApplicationController
-  include Achievement
   before_action :require_login
 
   # 　管理者アカウント作成のメソッド
@@ -30,7 +29,6 @@ class Api::V1::AdminsController < ApplicationController
     if params[:id] == "me"
       response = {}
       response["admin"] = @current_user
-
     else
       # IDから取得
       admin = Admin.find(params[:id])

--- a/api/app/controllers/api/v1/admins_controller.rb
+++ b/api/app/controllers/api/v1/admins_controller.rb
@@ -1,5 +1,6 @@
 # 管理者アカウントを作成するためのコントローラー
 class Api::V1::AdminsController < ApplicationController
+  include Achievement
   before_action :require_login
 
   # 　管理者アカウント作成のメソッド
@@ -25,8 +26,27 @@ class Api::V1::AdminsController < ApplicationController
 
   # 　管理者名を取得する
   def index
-    # 　管理者名を表示
-    render json: json_render_v1(true, @current_user)
+    # /meの場合、自身の情報を取得
+    if params[:id] == "me"
+      response = {}
+      response["admin"] = @current_user
+
+    else
+      # IDから取得
+      admin = Admin.find(params[:id])
+
+      # 存在しない場合はエラーを返す
+      if admin.nil? || admin.is_invalid
+        render json: json_render_v1(false, status: 204)
+        return
+      end
+
+      # 実績の取得
+      response = {}
+      response["admin"] = admin
+
+    end
+    render json: json_render_v1(true, response)
   end
 
   def delete

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
           post "admins" => "admins#create"
           patch "admins/:id" => "admins#update"
           delete "admins/:id" => "admins#delete"
-          get "admins/me" => "admins#index"
+          get "admins/:id" => "admins#index"
 
           # ガイド
           post "guides" => "guides#create"


### PR DESCRIPTION
## 作業内容
- #96を強化。/meの場合、今回のissueで指定された形で従来通りに表示。それ以外の場合、IDで検索して表示
- https://github.com/e-harp-intern/R4FY/wiki/admins-me
- https://github.com/e-harp-intern/R4FY/wiki/admins-index
## 確認内容
- postmanで正しく表示されることを確認