### PR TITLE
#199 ガイドアカウントの論理削除時にtokenも削除するAPI

### DIFF
--- a/api/app/controllers/api/v1/guides_controller.rb
+++ b/api/app/controllers/api/v1/guides_controller.rb
@@ -47,6 +47,10 @@ class Api::V1::GuidesController < ApplicationController
     guides_delete = Guide.find_by(id: params[:id])
     guides_delete.update(is_invalid: true)
 
+    # トークンの削除
+    tokens = Token.where(guide_id: params[:id])
+    tokens.destroy_all
+
     # アカウント削除の通知メール
     DeleteAccountNotifyMailer.delete_email(guides_delete).deliver_now
 


### PR DESCRIPTION
## 作業内容
- ガイドアカウントの論理削除時に紐づいたトークンも削除する
- wikiの更新もしました
- https://github.com/e-harp-intern/R4FY/wiki/guides-delete
## 確認内容
- DBで削除されたことを確認