### PR TITLE
#300 アカウント一覧APIのデフォルトパラメータを論理削除済みユーザーを除外する設定に変更

### DIFF
--- a/api/app/controllers/api/v1/accounts_controller.rb
+++ b/api/app/controllers/api/v1/accounts_controller.rb
@@ -6,17 +6,19 @@ class Api::V1::AccountsController < ApplicationController
   # アカウント一覧を取得
   def index
     # 条件の初期値を設定
-    # 検索に名前があるかないか
-    name = params[:name] || ""
-    # 検索にメールがあるかないか
-    email = params[:email] || ""
+
+    name = params[:name] || "" # 検索に名前があるかないか
+    email = params[:email] || "" # 検索にメールがあるかないか
+    include_invalid = params[:include_invalid] || false # 無効なユーザーを含むか
 
     account_admins = Admin
                      .where("name LIKE ?", "%#{name}%")
                      .where("email LIKE ?", "%#{email}%")
+                     .where(is_invalid: [include_invalid, false])
     account_guides = Guide
                      .where("name LIKE ?", "%#{name}%")
                      .where("email LIKE ?", "%#{email}%")
+                     .where(is_invalid: [include_invalid, false])
 
     response = {
         admins: account_admins,


### PR DESCRIPTION
wiki更新済み → [accounts · e-harp-intern/R4FY Wiki](https://github.com/e-harp-intern/R4FY/wiki/accounts)

## 確認事項
- デフォルトで論理削除済みユーザーを除外すること
- `include_invalid` が `true` で論理削除済みユーザーを含むこと
- `include_invalid` が `false` で論理削除済みユーザーを含まないこと