### PR TITLE
#292 ツアー詳細画面のタイトルのCSSが消えていたので修正

### DIFF
--- a/web/src/views/tours/TourDetailView.vue
+++ b/web/src/views/tours/TourDetailView.vue
@@ -236,6 +236,12 @@ export default {
 <style lang="scss" scoped>
 @import "@/assets/css/table.scss";
 
+#tour-name {
+  font-size: 3em;
+  text-align: center;
+  margin: 0;
+}
+
 h2 {
   margin: 50px 0 0 0;
 }


### PR DESCRIPTION
ごめんなさい。消してました。

## 確認事項
- ツアー詳細画面でツアー名が正しく表示されること