### PR TITLE
#230 担当者決定画面で担当者が決まっている場合に初期値を反映

### DIFF
--- a/web/src/views/tours/SelectGuidesView.vue
+++ b/web/src/views/tours/SelectGuidesView.vue
@@ -55,6 +55,7 @@
                 :id="schedule.id"
                 name="select-assign"
                 @click="ChangeSelect(schedule.state, schedule.id)"
+                v-model="schedule.assign"
                 v-if="isChecking === buttoncheck(schedule.state)"
               />
             </td>


### PR DESCRIPTION
## 確認事項
- 担当者決定画面で、すでに担当になっているガイドのチェックボックスに初期値としてチェックが入ること
- チェックの切り替えができること