### PR TITLE
#320 ツアー中止時に画面に反映されないことがある問題を修正

### DIFF
--- a/web/src/views/tours/TourDetailView.vue
+++ b/web/src/views/tours/TourDetailView.vue
@@ -150,10 +150,10 @@ export default {
     },
 
     // ツアー中止処理
-    alert_disp() {
+    async alert_disp() {
       if (window.confirm("ツアーの取り消しを実行しますか？")) {
         // 「OK」時の処理終了
-        api.delete(`/api/v1/tours/${this.tour.id}`);
+        await api.delete(`/api/v1/tours/${this.tour.id}`);
         window.alert("ツアーの中止を行いました。");
         this.$router.go({ path: this.$router.currentRoute.path, force: true }); // リロードする
       } else {
@@ -168,10 +168,10 @@ export default {
     },
 
     // 担当ガイド中止処理
-    alert_delete_guide() {
+    async alert_delete_guide() {
       if (window.confirm("担当ガイドの取り消しを実行しますか？")) {
         // 「OK」時の処理終了
-        api.delete(`/api/v1/tours/${this.tour.id}/guides`);
+        await api.delete(`/api/v1/tours/${this.tour.id}/guides`);
         window.alert("担当ガイドの取り消しを行いました。");
         this.$router.go({ path: this.$router.currentRoute.path, force: true }); // リロードする
       } else {


### PR DESCRIPTION
## 原因
- 中止処理を非同期実行していたことが原因でした。
- サーバーに負荷がかかっていると、中止処理よりも先に取得処理が行われ、更新されていないように見えているだけでした。

## 確認
- マージ後再度検証環境で動作確認