### PR TITLE
#317 マイナスの人数を登録できないようにバリデーションを追加

### DIFF
--- a/api/app/models/tour.rb
+++ b/api/app/models/tour.rb
@@ -4,4 +4,7 @@ class Tour < ApplicationRecord
   has_many :tour_guides
   has_many :tokens
   validates :end_datetime, comparison: { greater_than: :start_datetime }
+  validates :adult_num, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :child_num, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :guide_num, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 end


### PR DESCRIPTION
## 確認事項
- ツアー作成時に負の人数でエラーとなること

## 参考サイト
- [Railsで「整数のみ」、「０以上の正の数のみ」のvalidatesの書き方 - Qiita](https://qiita.com/syohhe/items/ecef500da2cd7956489d)