### PR TITLE
#227 実績入力時にツアー状態コードを変更するAPI

### DIFF
--- a/api/app/controllers/api/v1/achievements_controller.rb
+++ b/api/app/controllers/api/v1/achievements_controller.rb
@@ -14,9 +14,14 @@ class Api::V1::AchievementsController < ApplicationController
     # 実績入力
     achievements.update(achievements_entered: true)
 
-    # 全てのツアー実績が記入済みであれば、ツアー状態を更新
+    # ガイド全員の実績入力状態を取得
     tour_guides = TourGuide.where(tour_id: tour_id, achievements_entered: false)
     count = tour_guides.count
+
+    # 参加したガイド全員の実績を入力していない場合、ツアー状態コードを実施済みへ変更する
+    Tour.find_by(id: tour_id).update(tour_state_code: TOUR_STATE_CODE_COMPLETE) if count != 0
+
+    # 全てのツアー実績が記入済みであれば、ツアー状態を更新
     Tour.find_by(id: tour_id).update(tour_state_code: TOUR_STATE_CODE_COMPLETE_RECORDED) if count.zero?
 
     # 出席だけ入力

--- a/api/app/controllers/api/v1/guide_schedules_controller.rb
+++ b/api/app/controllers/api/v1/guide_schedules_controller.rb
@@ -16,11 +16,6 @@ class Api::V1::GuideSchedulesController < ApplicationController
       return
     end
 
-    # 参加したガイド全員の実績を入力していない場合、ツアー状態コードを実施済みへ変更する
-    tour_guides = TourGuide.where(tour_id: tour.id, achievements_entered: false)
-    count = tour_guides.count
-    tour.update(tour_state_code: TOUR_STATE_CODE_COMPLETE) if count != 0
-
     # 参加可否入力期限が過ぎていた場合
     if tour.schedule_input_deadline <= DateTime.now
       render json: json_render_v1(false, { state: "error" })

--- a/api/app/controllers/api/v1/guide_schedules_controller.rb
+++ b/api/app/controllers/api/v1/guide_schedules_controller.rb
@@ -25,7 +25,7 @@ class Api::V1::GuideSchedulesController < ApplicationController
     # ガイドアカウントが有効な場合
     guide_schedules = GuideSchedule.find_by(guide_id: token.guide_id, tour_id: token.tour_id)
     guide_schedules.update(answered: true, possible: params[:possible])
-    render json: json_render_v1(true, guides)
+    render json: json_render_v1(true, guide)
   end
 
   # ガイド情報・関連したツアー情報・入力済の参加可否情報の表示

--- a/api/app/controllers/api/v1/guide_schedules_controller.rb
+++ b/api/app/controllers/api/v1/guide_schedules_controller.rb
@@ -25,7 +25,7 @@ class Api::V1::GuideSchedulesController < ApplicationController
     # ガイドアカウントが有効な場合
     guide_schedules = GuideSchedule.find_by(guide_id: token.guide_id, tour_id: token.tour_id)
     guide_schedules.update(answered: true, possible: params[:possible])
-    render json: json_render_v1(true)
+    render json: json_render_v1(true, guides)
   end
 
   # ガイド情報・関連したツアー情報・入力済の参加可否情報の表示

--- a/api/app/controllers/api/v1/guide_schedules_controller.rb
+++ b/api/app/controllers/api/v1/guide_schedules_controller.rb
@@ -16,16 +16,16 @@ class Api::V1::GuideSchedulesController < ApplicationController
       return
     end
 
+    # 参加したガイド全員の実績を入力していない場合、ツアー状態コードを実施済みへ変更する
+    tour_guides = TourGuide.where(tour_id: tour.id, achievements_entered: false)
+    count = tour_guides.count
+    tour.update(tour_state_code: TOUR_STATE_CODE_COMPLETE) if count != 0
+
     # 参加可否入力期限が過ぎていた場合
     if tour.schedule_input_deadline <= DateTime.now
       render json: json_render_v1(false, { state: "error" })
       return
     end
-
-    # 参加したガイド全員の実績を入力していない場合、ツアー状態コードを実施済みへ変更する
-    tour_guides = TourGuide.where(tour_id: tour.id, achievements_entered: false)
-    count = tour_guides.count
-    tour.update(tour_state_code: TOUR_STATE_CODE_COMPLETE) if count != 0
 
     # ガイドアカウントが有効な場合
     guide_schedules = GuideSchedule.find_by(guide_id: token.guide_id, tour_id: token.tour_id)

--- a/api/app/controllers/api/v1/guide_schedules_controller.rb
+++ b/api/app/controllers/api/v1/guide_schedules_controller.rb
@@ -22,10 +22,15 @@ class Api::V1::GuideSchedulesController < ApplicationController
       return
     end
 
+    # 参加したガイド全員の実績を入力していない場合、ツアー状態コードを実施済みへ変更する
+    tour_guides = TourGuide.where(tour_id: tour.id, achievements_entered: false)
+    count = tour_guides.count
+    tour.update(tour_state_code: TOUR_STATE_CODE_COMPLETE) if count != 0
+
     # ガイドアカウントが有効な場合
     guide_schedules = GuideSchedule.find_by(guide_id: token.guide_id, tour_id: token.tour_id)
     guide_schedules.update(answered: true, possible: params[:possible])
-    render json: json_render_v1(true, guide)
+    render json: json_render_v1(true)
   end
 
   # ガイド情報・関連したツアー情報・入力済の参加可否情報の表示


### PR DESCRIPTION
## 作業内容
- 実績入力時、参加したガイド全員が実績入力済ではなかった場合、ツアー状態コードを変更する機能
## 確認内容
- DBで正しく変更されることを確認