### PR TITLE
#337 Railsのログに^{[0m ^{[1mが入らないように設定を変更

### DIFF
--- a/api/config/environments/development.rb
+++ b/api/config/environments/development.rb
@@ -61,4 +61,7 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  # log
+  config.colorize_logging = false
 end


### PR DESCRIPTION
ログが少しきれいになりました。