### PR TITLE
#286 予定作成メールの再送機能

### DIFF
--- a/api/app/controllers/api/v1/tour_schedules_controller.rb
+++ b/api/app/controllers/api/v1/tour_schedules_controller.rb
@@ -1,0 +1,28 @@
+# 予定入力メールを再送するコントローラーです
+
+class Api::V1::TourSchedulesController < ApplicationController
+  before_action :require_login
+
+  # 予定入力メールを再送
+  def create
+    # ツアーを取得
+    tour = Tour.find_by(id: params[:tour_id])
+
+    # ガイドのリストを取得（削除済みをのぞく）
+    guides = Guide.where(id: params[:guides])
+
+    # ガイドに予定入力メールを送信
+    guides.each do |guide|
+      # ガイドが存在する場合、トークンを取得
+      token = Token.find_by(tour_id: tour.id, guide_id: guide.id) unless guide.nil? && guide.is_invalid
+
+      # トークンが存在する場合、メールを送信
+      unless token.nil?
+        url = format(URL_GUIDE_SCHEDULE_TOKEN, token: token.token)
+        GuideScheduleInputMailer.creation_email(guide, url).deliver_now
+      end
+    end
+
+    render json: json_render_v1(true)
+  end
+end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
           get "tours/:id" => "tour#index"
           delete "tours/:id" => "tour#destroy"
           patch "tours/:id" => "tour#update"
+          post "tours/:tour_id/schedules/mail" => "tour_schedules#create"
 
           # ツアー／実績
           get "tours/:tour_id/achievements" => "tour_achievements#index"


### PR DESCRIPTION
## 作業内容
- 予定作成メールを再送する機能を追加
- https://github.com/e-harp-intern/R4FY/wiki/tour_schedule-create
## 確認内容
- postmanとmailを確認