### PR TITLE
#236 担当ガイド取り消しメール

### DIFF
--- a/api/app/controllers/api/v1/tour_guides_controller.rb
+++ b/api/app/controllers/api/v1/tour_guides_controller.rb
@@ -44,9 +44,17 @@ class Api::V1::TourGuidesController < ApplicationController
     # トランザクション（失敗時は保持しない）
     ApplicationRecord.transaction do
       tour_id = params[:id]
+      tour_guides = TourGuide.where(tour_id: tour_id)
+      tour_delete = Tour.find_by(id: params[:id])
+
+      # 全員にメールを送信
+      tour_guides.each do |tour_guide|
+        guide = Guide.find_by(id: tour_guide.guide_id)
+        TourCancelNotifyMailer.cancel_email(guide, tour_delete).deliver_now
+      end
 
       # 同じツアーIDの担当情報を削除（物理）
-      TourGuide.where(tour_id: tour_id).destroy_all
+      tour_guides.destroy_all
 
       # ツアーの状態を「担当ガイド未決定」に更新
       Tour.find(tour_id).update(tour_state_code: TOUR_STATE_CODE_INCOMPLETE)

--- a/api/app/controllers/api/v1/tour_guides_controller.rb
+++ b/api/app/controllers/api/v1/tour_guides_controller.rb
@@ -50,7 +50,7 @@ class Api::V1::TourGuidesController < ApplicationController
       # 全員にメールを送信
       tour_guides.each do |tour_guide|
         guide = Guide.find_by(id: tour_guide.guide_id)
-        TourCancelNotifyMailer.cancel_email(guide, tour_delete).deliver_now
+        AssignCancelNotifyMailer.cancel_email(guide, tour_delete).deliver_now
       end
 
       # 同じツアーIDの担当情報を削除（物理）

--- a/api/app/mailers/assign_cancel_notify_mailer.rb
+++ b/api/app/mailers/assign_cancel_notify_mailer.rb
@@ -1,0 +1,10 @@
+class AssignCancelNotifyMailer < ApplicationMailer
+  def cancel_email(guide, tour)
+    @guide = guide
+    @tour = tour
+    mail(
+      subject: "【担当取り消し通知】ツアー担当ガイド取り消し通知",
+      to: guide.email
+    )
+  end
+end

--- a/api/app/views/assign_cancel_notify_mailer/cancel_email.text.erb
+++ b/api/app/views/assign_cancel_notify_mailer/cancel_email.text.erb
@@ -1,0 +1,11 @@
+<%= @guide.name %>様
+ツアーの担当から外されましたので、ご連絡いたします。
+
+ツアー名：<%= @tour.name %>
+開催日：<%= @tour.start_datetime.strftime('%Y/%m/%d %H:%M') %> ～ <%= @tour.end_datetime.strftime('%Y/%m/%d %H:%M') %>
+
+
+------------------------------
+
+観光地ガイド調整システム
+admin@harp-intern.local


### PR DESCRIPTION
## 作業内容
- 担当ガイドをリセットした際に、担当者全員に通知メールが行くよう設定
- wikiの更新 https://github.com/e-harp-intern/R4FY/wiki/tour-id-guides-delete
## 確認内容
- mailを確認