### PR TITLE
#232 担当ガイド割り当てメール送信フラグを追加

### DIFF
--- a/api/app/controllers/api/v1/tour_guides_controller.rb
+++ b/api/app/controllers/api/v1/tour_guides_controller.rb
@@ -7,7 +7,10 @@ class Api::V1::TourGuidesController < ApplicationController
     # パラメータの受け取り
     tour_id = params[:id]
     guides = params[:guides]
-    send_mail = params[:send_mail]
+
+    # send_mailは初期値はtrue
+    send_mail = true
+    send_mail = params[:send_mail] unless params[:send_mail].nil? || params[:send_mail] == ""
 
     # トランザクション（失敗時は保存しない）
     ApplicationRecord.transaction do

--- a/api/app/controllers/api/v1/tour_guides_controller.rb
+++ b/api/app/controllers/api/v1/tour_guides_controller.rb
@@ -9,8 +9,7 @@ class Api::V1::TourGuidesController < ApplicationController
     guides = params[:guides]
 
     # send_mailは初期値はtrue
-    send_mail = true
-    send_mail = params[:send_mail] unless params[:send_mail].nil? || params[:send_mail] == ""
+    send_mail = params[:send_mail] || true
 
     # トランザクション（失敗時は保存しない）
     ApplicationRecord.transaction do

--- a/api/app/controllers/api/v1/tour_guides_controller.rb
+++ b/api/app/controllers/api/v1/tour_guides_controller.rb
@@ -7,6 +7,7 @@ class Api::V1::TourGuidesController < ApplicationController
     # パラメータの受け取り
     tour_id = params[:id]
     guides = params[:guides]
+    send_mail = params[:send_mail]
 
     # トランザクション（失敗時は保存しない）
     ApplicationRecord.transaction do
@@ -23,11 +24,13 @@ class Api::V1::TourGuidesController < ApplicationController
       Tour.find(tour_id).update(tour_state_code: TOUR_STATE_CODE_ASSIGNED)
     end
 
-    # 成功時に担当者にメールを送信
-    tour = Tour.find(tour_id)
-    guides.each do |g|
-      guide = Guide.find_by(id: g)
-      AssignNotifyMailer.creation_email(guide, tour).deliver_now
+    # 成功時にsend_mailがtrueなら担当者にメールを送信
+    if send_mail == true
+      tour = Tour.find(tour_id)
+      guides.each do |g|
+        guide = Guide.find_by(id: g)
+        AssignNotifyMailer.creation_email(guide, tour).deliver_now
+      end
     end
 
     # 成功時


### PR DESCRIPTION
## 作業内容
- 担当ガイド割り当てフラグを追加。初期値はtrueで、falseになった場合、メールを送信しない。
- wikiの更新 https://github.com/e-harp-intern/R4FY/wiki/tour-id-guides-post
## 確認内容
- mailを確認