### PR TITLE
#343 ガイド側の予定入力・確認に制限

### DIFF
--- a/api/app/controllers/api/v1/guide_schedules_controller.rb
+++ b/api/app/controllers/api/v1/guide_schedules_controller.rb
@@ -23,6 +23,18 @@ class Api::V1::GuideSchedulesController < ApplicationController
       return
     end
 
+    # ツアーが開始済みの場合
+    if tour.start_datetime < Date.today
+      render json: json_render_v1(false)
+      return
+    end
+
+    # 担当者が決定済の場合
+    if tour.tour_state_code != TOUR_STATE_CODE_INCOMPLETE
+      render json: json_render_v1(false)
+      return
+    end
+
     # ガイドパラメーター
     guide = Guide.find_by(id: token.guide_id)
 
@@ -61,6 +73,18 @@ class Api::V1::GuideSchedulesController < ApplicationController
     # ツアーが中止済みの場合
     if tour.tour_state_code == TOUR_STATE_CODE_CANCEL
       render json: json_render_v1(false, { state: "tour canceled" })
+      return
+    end
+
+    # ツアーが開始済みの場合
+    if tour.start_datetime < Date.today
+      render json: json_render_v1(false)
+      return
+    end
+
+    # 担当者が決定済の場合
+    if tour.tour_state_code != TOUR_STATE_CODE_INCOMPLETE
+      render json: json_render_v1(false)
       return
     end
 

--- a/api/app/controllers/api/v1/guide_schedules_controller.rb
+++ b/api/app/controllers/api/v1/guide_schedules_controller.rb
@@ -23,14 +23,8 @@ class Api::V1::GuideSchedulesController < ApplicationController
       return
     end
 
-    # ツアーが開始済みの場合
-    if tour.start_datetime < Date.today
-      render json: json_render_v1(false)
-      return
-    end
-
-    # 担当者が決定済の場合
-    if tour.tour_state_code != TOUR_STATE_CODE_INCOMPLETE
+    # ツアーが開始済みの場合・担当者が決定済
+    if tour.start_datetime < Date.today || tour.tour_state_code != TOUR_STATE_CODE_INCOMPLETE
       render json: json_render_v1(false)
       return
     end
@@ -38,15 +32,9 @@ class Api::V1::GuideSchedulesController < ApplicationController
     # ガイドパラメーター
     guide = Guide.find_by(id: token.guide_id)
 
-    # ガイドアカウントが無効な場合
-    if guide.is_invalid == true
+    # ガイドアカウントが無効・参加可否入力期限が過ぎていた場合
+    if guide.is_invalid == true || tour.schedule_input_deadline <= DateTime.now
       render json: json_render_v1(false)
-      return
-    end
-
-    # 参加可否入力期限が過ぎていた場合
-    if tour.schedule_input_deadline <= DateTime.now
-      render json: json_render_v1(false, { state: "error" })
       return
     end
 
@@ -76,14 +64,8 @@ class Api::V1::GuideSchedulesController < ApplicationController
       return
     end
 
-    # ツアーが開始済みの場合
-    if tour.start_datetime < Date.today
-      render json: json_render_v1(false)
-      return
-    end
-
-    # 担当者が決定済の場合
-    if tour.tour_state_code != TOUR_STATE_CODE_INCOMPLETE
+    # ツアーが開始済みの場合・担当者が決定済の場合
+    if tour.start_datetime < Date.today || tour.tour_state_code != TOUR_STATE_CODE_INCOMPLETE
       render json: json_render_v1(false)
       return
     end


### PR DESCRIPTION
## 作業内容
- ガイド側で予定入力・確認を行ったとき、ツアーが開始済みの場合と担当者が決定済みの場合に制限がかかるよう設定
## 確認内容
- postmanで確認