### PR TITLE
#365 パスワード再設定画面でパスワードが違う場合に再設定を行なわないように修正

### DIFF
--- a/web/src/views/PasswordResetView.vue
+++ b/web/src/views/PasswordResetView.vue
@@ -50,6 +50,7 @@ export default {
       // パスワードが違う
       if (password !== re_password) {
         alert(this.$t("pages.password_reset.alert_password"));
+        return;
       }
 
       // 送信


### PR DESCRIPTION
オートフォーマットに`return`を消されたことが原因でした。