### PR TITLE
#174 担当ガイド決定画面からガイド情報画面へのリンクを追加

### DIFF
--- a/web/src/i18n/languages/ja.js
+++ b/web/src/i18n/languages/ja.js
@@ -184,7 +184,8 @@ export default {
             name: "名前",
             email: "メールアドレス",
             answered_state: "参加可否",
-            assign_mark: "〇"
+            assign_mark: "〇",
+            link: "ガイド情報"
         },
         account: {
             authority: "権限",
@@ -218,7 +219,8 @@ export default {
         date_start_end: "%{start} ~ %{end}",
         name: "%{name} 様",
         router_back: "前のページへ戻る",
-        cancel: "取り消しました。"
+        cancel: "取り消しました。",
+        check: "確認"
     },
     system: {
         datetime: "%{year}-%{month}-%{date} %{hours}:%{minutes}"

--- a/web/src/views/tours/SelectGuidesView.vue
+++ b/web/src/views/tours/SelectGuidesView.vue
@@ -41,6 +41,9 @@
             <th @click="sortBy('state')" :class="addSortClass('state')">
               {{ $t("table.guide.answered_state") }}
             </th>
+            <th>
+              {{ $t("table.guide.link") }}
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -49,9 +52,11 @@
             :key="schedule.id"
             :class="tableCSS(schedule.state)"
             class="hover-line"
-            @click="ChangeSelect(schedule.state, schedule.id)"
           >
-            <td class="center">
+            <td
+              @click="ChangeSelect(schedule.state, schedule.id)"
+              class="center"
+            >
               <input
                 type="checkbox"
                 style="transform: scale(2)"
@@ -62,10 +67,24 @@
                 v-if="isChecking === buttoncheck(schedule.state)"
               />
             </td>
-            <td>{{ schedule.name }}</td>
-            <td>{{ schedule.email }}</td>
-            <td class="center">
+            <td @click="ChangeSelect(schedule.state, schedule.id)">
+              {{ schedule.name }}
+            </td>
+            <td @click="ChangeSelect(schedule.state, schedule.id)">
+              {{ schedule.email }}
+            </td>
+            <td
+              @click="ChangeSelect(schedule.state, schedule.id)"
+              class="center"
+            >
               {{ codeToGuideStateString(schedule.state) }}
+            </td>
+            <td class="center">
+              <a
+                @click="LinkGuide(schedule.guide_id)"
+                href="javascript:void(0)"
+                >{{ $t("common.check") }}</a
+              >
             </td>
           </tr>
         </tbody>
@@ -105,6 +124,11 @@ export default {
     // 参加の有無によってチェックボックスの表示・非表示
     buttoncheck(state) {
       return state === 1 ? 1 : 2;
+    },
+
+    // ガイドへのリンク
+    LinkGuide(id) {
+      window.open(`/accounts/guides/${id}`, "_blank");
     },
 
     // チェック済みガイド数をカウントする


### PR DESCRIPTION
表に追加することが難しいので、別タブで情報を開く仕様にしました。