### PR TITLE
#231 担当ガイド割り当て時の挙動を修正

### DIFF
--- a/api/app/controllers/api/v1/tour_guides_controller.rb
+++ b/api/app/controllers/api/v1/tour_guides_controller.rb
@@ -15,11 +15,11 @@ class Api::V1::TourGuidesController < ApplicationController
 
     ApplicationRecord.transaction do
       # 担当から外れたガイドを取得
-      guides = TourGuide.where(tour_id: tour_id).where(guide_id: guides)
-      guides.each do |g|
+      del_guides = TourGuide.where(tour_id: tour_id).where.not(guide_id: guides)
+      del_guides.each do |g|
         remove_assign.push(g)
       end
-      guides.destroy_all
+      del_guides.destroy_all
 
       # 担当ガイドを追加（TODO: 削除済みのガイドを指定した場合はエラー）
       guides.each do |g|
@@ -32,26 +32,25 @@ class Api::V1::TourGuidesController < ApplicationController
 
       # ツアーの状態を担当者決定済みに更新
       is_first_assign = (tour.tour_state_code < TOUR_STATE_CODE_ASSIGNED)
-      tour.update(tour_state_code: TOUR_STATE_CODE_ASSIGNED)
+      tour.update(tour_state_code: TOUR_STATE_CODE_ASSIGNED) if is_first_assign
 
       # 成功時にsend_mailがtrueなら担当者にメールを送信
       if send_mail == true
         # 新しく担当者になった人へメール送信
         new_assign.each do |g|
-          guide = Guide.find_by(id: g)
-          AssignNotifyMailer.creation_email(guide, tour).deliver_now
+          AssignNotifyMailer.creation_email(Guide.find(g.guide_id), tour).deliver_now
         end
 
         # 担当から外れた場合に送信
         remove_assign.each do |g|
-          # TODO: 割り当てから外れたメールを送信
+          AssignCancelNotifyMailer.cancel_email(Guide.find(g.guide_id), tour).deliver_now
         end
 
         # 担当にならなかった場合に送信
         if is_first_assign
-          guides = TourGuide.where(tour_id: tour_id).where.not(guide_id: guides)
-          guides.each do |g|
-            # TODO: ならなかったメールを送信
+          no_assign_guides = GuideSchedule.where(tour_id: tour_id).where.not(guide_id: guides)
+          no_assign_guides.each do |g|
+            NotAssignMailer.creation_email(Guide.find(g.guide_id), tour).deliver_now
           end
         end
       end

--- a/api/app/controllers/api/v1/tour_guides_controller.rb
+++ b/api/app/controllers/api/v1/tour_guides_controller.rb
@@ -7,31 +7,53 @@ class Api::V1::TourGuidesController < ApplicationController
     # パラメータの受け取り
     tour_id = params[:id]
     guides = params[:guides]
-
-    # send_mailは初期値はtrue
     send_mail = params[:send_mail] || true
+    new_assign = []
+    remove_assign = []
+    is_first_assign = false
+    tour = Tour.find(tour_id)
 
-    # トランザクション（失敗時は保存しない）
     ApplicationRecord.transaction do
-      # 同じツアーIDの担当情報を削除（物理）
-      TourGuide.where(tour_id: tour_id).destroy_all
-
-      # 追加（TODO: 削除済みのガイドを指定した場合はエラー）
+      # 担当から外れたガイドを取得
+      guides = TourGuide.where(tour_id: tour_id).where(guide_id: guides)
       guides.each do |g|
+        remove_assign.push(g)
+      end
+      guides.destroy_all
+
+      # 担当ガイドを追加（TODO: 削除済みのガイドを指定した場合はエラー）
+      guides.each do |g|
+        next unless TourGuide.find_by(tour_id: tour_id, guide_id: g).nil?
+
         t = TourGuide.new(tour_id: tour_id, guide_id: g)
+        new_assign.push(t)
         t.save
       end
 
       # ツアーの状態を担当者決定済みに更新
-      Tour.find(tour_id).update(tour_state_code: TOUR_STATE_CODE_ASSIGNED)
-    end
+      is_first_assign = (tour.tour_state_code < TOUR_STATE_CODE_ASSIGNED)
+      tour.update(tour_state_code: TOUR_STATE_CODE_ASSIGNED)
 
-    # 成功時にsend_mailがtrueなら担当者にメールを送信
-    if send_mail == true
-      tour = Tour.find(tour_id)
-      guides.each do |g|
-        guide = Guide.find_by(id: g)
-        AssignNotifyMailer.creation_email(guide, tour).deliver_now
+      # 成功時にsend_mailがtrueなら担当者にメールを送信
+      if send_mail == true
+        # 新しく担当者になった人へメール送信
+        new_assign.each do |g|
+          guide = Guide.find_by(id: g)
+          AssignNotifyMailer.creation_email(guide, tour).deliver_now
+        end
+
+        # 担当から外れた場合に送信
+        remove_assign.each do |g|
+          # TODO: 割り当てから外れたメールを送信
+        end
+
+        # 担当にならなかった場合に送信
+        if is_first_assign
+          guides = TourGuide.where(tour_id: tour_id).where.not(guide_id: guides)
+          guides.each do |g|
+            # TODO: ならなかったメールを送信
+          end
+        end
       end
     end
 

--- a/api/app/mailers/not_assign_mailer.rb
+++ b/api/app/mailers/not_assign_mailer.rb
@@ -1,0 +1,10 @@
+class NotAssignMailer < ApplicationMailer
+  def creation_email(guide, tour)
+    @guide = guide
+    @tour = tour
+    mail(
+      subject: "【お知らせ】ツアーの担当ガイドになりませんでした",
+      to: guide.email
+    )
+  end
+end

--- a/api/app/views/not_assign_mailer/creation_email.text.erb
+++ b/api/app/views/not_assign_mailer/creation_email.text.erb
@@ -1,0 +1,16 @@
+<%= @guide.name %>様
+
+予定入力のご協力ありがとうございました。
+下記ツアーの担当に割り当てられませんでしたのでお知らせいたします。
+
+
+ツアー名：<%= @tour.name %>
+開催日：<%= @tour.start_datetime.strftime('%Y/%m/%d %H:%M') %> ～ <%= @tour.end_datetime.strftime('%Y/%m/%d %H:%M') %>
+
+
+またのご協力お願いいたします。
+
+------------------------------
+
+観光地ガイド調整システム
+admin@harp-intern.local


### PR DESCRIPTION
## 確認事項
- 設定が正しく行われる
- 初回のみ「割り当たらなかったメール」を送信する
- 新しく割り当てられたガイドに「割り当てメール」を送信する
- 割り当てから外れたガイドに「担当から外れたメール」を送信する