### PR TITLE
#425 ツアーガイド決定APIのメール送信有無パラメータが正しく処理されるよう修正

### DIFF
--- a/api/app/controllers/api/v1/tour_guides_controller.rb
+++ b/api/app/controllers/api/v1/tour_guides_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::TourGuidesController < ApplicationController
     # パラメータの受け取り
     tour_id = params[:id]
     guides = params[:guides]
-    send_mail = params[:send_mail] || true
+    send_mail = params[:send_mail].nil? ? true : params[:send_mail]
     new_assign = []
     remove_assign = []
     is_first_assign = false


### PR DESCRIPTION
[[Rails]POSTで送ったboolean値がおかしかった原因 - Qiita](https://qiita.com/chocode/items/e00435abac0bc459f0e6) デフォルト値処理が原因でした。