### PR TITLE
#424 ツアー一覧で検索時に並び替え条件を保持

### DIFF
--- a/web/src/mixins/table.js
+++ b/web/src/mixins/table.js
@@ -10,6 +10,12 @@ export default {
     methods: {
         /* テーブルのソートを開始 */
         sortBy(key, array) {
+            // keyにnullを指定した場合、現在と同じ条件で並び替えをする
+            if(key == null){
+                key =  this.sort_key;
+                this.sort_asc = !this.sort_asc;
+            }
+
             // 前回の選択と同じタイトルを選択された場合、sort_ascを切り替え、昇順降順処理の切り替えを行う
             this.sort_asc = this.sort_key !== key ? true : !this.sort_asc;
             this.sort_key = key;

--- a/web/src/views/ToursListView.vue
+++ b/web/src/views/ToursListView.vue
@@ -200,7 +200,12 @@ export default {
       // 送信
       const response = await api.get(url, request, this.$router.push);
 
-      this.tours = response.data;
+      const tours = response.data;
+
+      // 並び替え
+      table.methods.sortBy(null, tours);
+
+      this.tours = tours;
     },
   },
   created() {


### PR DESCRIPTION
並び替えキーに`null`を指定した場合に、前回並び替え時と同じ条件で並び変わるようにしました。