### PR TITLE
#570 担当ガイド決定画面でグレーアウトのガイドを選択できないように修正

### DIFF
--- a/web/src/components/GuidesTable.vue
+++ b/web/src/components/GuidesTable.vue
@@ -48,7 +48,7 @@
           <td
             v-if="setting.checkbox"
             class="center"
-            @click="guide.checked = !guide.checked"
+            @click="checkChange(guide)"
           >
             <input
               v-if="
@@ -144,9 +144,23 @@ export default {
     // 担当割り当てができない場合はグレーアウト
     tableCSS(state) {
       return {
-        grayout: state !== 1 && this.setting.grayout,
-        "table-hover": state === 1 || this.setting.grayout !== true,
+        grayout: this.isGrayout(state),
+        "table-hover": !this.isGrayout(state),
       };
+    },
+
+    // グレーアウトするかの判定
+    isGrayout(state) {
+      return state !== 1 && this.setting.grayout;
+    },
+
+    // チェックボックスの処理
+    checkChange(guide) {
+      if (this.isGrayout(guide.state)) {
+        return;
+      }
+
+      guide.checked = !guide.checked;
     },
 
     // ツアー状態によって色を付ける

--- a/web/src/views/tours/SelectGuidesView.vue
+++ b/web/src/views/tours/SelectGuidesView.vue
@@ -187,7 +187,6 @@ export default {
       g.email = g.guide.email;
       g.state = guideStateMethod(g.answered, g.possible);
       g.checked = tourguides.some((u) => u.guide.id === g.guide.id);
-      if (g.state !== 1) g.checked = false;
       g.id = `select-assign-${g.guide_id}`;
       g.memo = g.guide.memo;
       const temp = achievements.find((a) => a.guide_id === g.guide.id);


### PR DESCRIPTION
グレーアウトの存在を考慮し忘れていることが原因です。